### PR TITLE
Custom cache suffix

### DIFF
--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -30,11 +30,14 @@ component {
 
 	private void function _configureAdminTheme( settings ) {
 		settings.admin = {
-			  topNavItems     = []
-			, topNavMenuIcons = true
-			, favicon         = "/preside/system/assets/extension/preside-ext-alt-admin-theme/assets/images/preside-favicon.png"
-			, adminAvatarSize = 56
-			, customCss       = []
+			  topNavItems       = []
+			, topNavMenuIcons   = true
+			, favicon           = "/preside/system/assets/extension/preside-ext-alt-admin-theme/assets/images/preside-favicon.png"
+			, adminAvatarSize   = 56
+			, customCss         = []
+			, topNavCacheSuffix = function( event, args={} ){
+				return event.getAdminUserId();
+			}
 		};
 	}
 

--- a/views/admin/util/topNav.cfm
+++ b/views/admin/util/topNav.cfm
@@ -1,8 +1,14 @@
 <cfscript>
+	cacheSuffix = getSetting( name="admin.topNavCacheSuffix", defaultValue=event.getAdminUserId() );
+
+	if ( isClosure( cacheSuffix ) || isCustomFunction( cacheSuffix ) ) {
+		cacheSuffix = cacheSuffix( event, args );
+	}
+
 	topLevelNav       = renderView( view="/admin/util/topNavItems" );
-	userMenu          = renderView( view="/admin/util/userMenu", cache=true, cacheSuffix=event.getAdminUserId() );
-	applicationNav    = renderViewlet( event="admin.layout.applicationNav", cache=true, cacheSuffix=event.getAdminUserId() );
-	systemMenu        = renderView( view="/admin/util/topnav/system", cache=true, cacheSuffix=event.getAdminUserId() );
+	userMenu          = renderView( view="/admin/util/userMenu", cache=true, cacheSuffix=cacheSuffix );
+	applicationNav    = renderViewlet( event="admin.layout.applicationNav", cache=true, cacheSuffix=cacheSuffix );
+	systemMenu        = renderView( view="/admin/util/topnav/system", cache=true, cacheSuffix=cacheSuffix );
 	notificationsMenu = renderViewlet( "admin.notifications.notificationNavPromo" );
 	systemAlertsMenu  = renderViewlet( "admin.systemAlerts.systemAlertsMenuItem" );
 	sitePicker        = isFeatureEnabled( "siteSwitcher" ) ? renderViewlet( "admin.sites.sitePicker" ) : "";


### PR DESCRIPTION
Allow top nav cache suffix customisation for data tenanting (e.g. site tenanted rules engine). Defaults to admin user ID