### PR TITLE
ADMINTHEME-101 2FA flag are incorrect if a site has authentication enforced

### DIFF
--- a/handlers/admin/datamanager/security_user.cfc
+++ b/handlers/admin/datamanager/security_user.cfc
@@ -114,7 +114,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 			}
 
 			if ( loginService.isTwoFactorAuthenticationEnabled() ) {
-				if ( isTrue( prc.record.two_step_auth_key_in_use ?: "" ) ) {
+				if ( isTrue( prc.record.has_two_step_auth ?: "" ) ) {
 					ArrayAppend( children, {
 						  link   = event.buildAdminLink( linkTo="datamanager.security_user.disableTwoFactorAuthAction", queryString="id=#recordId#" )
 						, icon   = "fa-unlock red"

--- a/preside-objects/security_user.cfc
+++ b/preside-objects/security_user.cfc
@@ -7,7 +7,7 @@ component {
 	property name="groups" showNoValue=false;
 	property name="two_step_auth_enabled" renderer="Boolean";
 
-	property name="has_two_step_auth" formula="${prefix}two_step_auth_enabled AND ${prefix}two_step_auth_key_in_use" autoFilter=false excludeDataExport=true renderer="boolean";
+	property name="has_two_step_auth" formula="IF( ISNULL( ${prefix}two_step_auth_key ), 0, 1 ) AND ${prefix}two_step_auth_key_in_use" autoFilter=false excludeDataExport=true renderer="boolean";
 	property name="group_labels"      formula="group_concat( distinct ${prefix}groups.label, ',' )" autoFilter=false excludeDataExport=true adminRenderer="none" renderer="AdminSecurityUserGroups";
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts how a user's 2FA status is computed and ensures the admin action checks the computed flag.
> 
> - **Security User model**:
>   - Update `has_two_step_auth` formula to `IF( ISNULL( ${prefix}two_step_auth_key ), 0, 1 ) AND ${prefix}two_step_auth_key_in_use`.
> - **Admin UI**:
>   - Use `prc.record.has_two_step_auth` to conditionally show the "disable 2FA" action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54f9a1bb49ce6f3bc27534fe5cc68f5581bbd22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->