### PR TITLE
ADMINTHEME-109 admin filter segmentations dynamic tag style

### DIFF
--- a/assets/css/admin/altadmintheme/pixl8-core.less
+++ b/assets/css/admin/altadmintheme/pixl8-core.less
@@ -11,6 +11,12 @@
 			// background-image : url( ../../../../images/logos/header-logo.png );
 			// width            : 180px;
 		}
+
+		.segmentation-tags {
+			.segmentation-tag {
+				color : var( --color-primary-100 );
+			}
+		}
 	}
 
 	.table.no-border {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds styling for segmentation tags in the admin theme.
> 
> - In `assets/css/admin/altadmintheme/pixl8-core.less`, defines `.preside-theme .segmentation-tags .segmentation-tag { color: var(--color-primary-100); }` to standardize tag color
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac25881b1ed5c962932cabff8a139c30908cf0ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->