### PR TITLE
ADMINTHEME-108: hide breadcrumbs option

### DIFF
--- a/layouts/admin.cfm
+++ b/layouts/admin.cfm
@@ -2,7 +2,7 @@
 	body             = renderView();
 	navbar           = renderView( "admin/util/topNav" );
 	siteAlerts       = renderViewlet( "admin.layout.siteAlerts" );
-	breadcrumbs      = renderView( "admin/layout/breadcrumbs" );
+	breadcrumbs      = ( prc.hideBreadcrumbs ?: false ) ? "" : renderView( "admin/layout/breadcrumbs" );
 	adminSidebar     = renderViewlet( "admin.layout.renderAdminSidebar" );
 	adminFooter      = renderViewlet( "admin.general.footer" );
 	notifications    = renderView( "admin/general/notifications" );
@@ -106,16 +106,18 @@
 
 		<script nonce="#event?.getRequestNonce()#">
 			var topRightButtonGroups = document.querySelectorAll( "div.top-right-button-group" )
-			  , breadcrumbDiv        = document.querySelector( "##breadcrumbs")
+			  , breadcrumbDiv        = document.querySelector( "##breadcrumbs" )
 			  , moved                = false;
 
-			topRightButtonGroups.forEach( function( buttonGroup ){
-			    buttonGroup = buttonGroup.parentNode.removeChild( buttonGroup );
-				if ( !moved ) {
-					breadcrumbDiv.insertAdjacentHTML( "beforeend", buttonGroup.outerHTML );
-					moved = true;
-				}
-			} );
+			if ( breadcrumbDiv ) {
+				topRightButtonGroups.forEach( function( buttonGroup ){
+					buttonGroup = buttonGroup.parentNode.removeChild( buttonGroup );
+					if ( !moved ) {
+						breadcrumbDiv.insertAdjacentHTML( "beforeend", buttonGroup.outerHTML );
+						moved = true;
+					}
+				} );
+			}
 		</script>
 
 		#ckEditorJs#

--- a/layouts/admin.cfm
+++ b/layouts/admin.cfm
@@ -2,7 +2,7 @@
 	body             = renderView();
 	navbar           = renderView( "admin/util/topNav" );
 	siteAlerts       = renderViewlet( "admin.layout.siteAlerts" );
-	breadcrumbs      = ( prc.hideBreadcrumbs ?: false ) ? "" : renderView( "admin/layout/breadcrumbs" );
+	breadcrumbs      = IsTrue( prc.hideBreadcrumbs ?: false ) ? "" : renderView( "admin/layout/breadcrumbs" );
 	adminSidebar     = renderViewlet( "admin.layout.renderAdminSidebar" );
 	adminFooter      = renderViewlet( "admin.general.footer" );
 	notifications    = renderView( "admin/general/notifications" );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an option to suppress breadcrumbs and hardens related UI behavior.
> 
> - Conditionally renders `breadcrumbs` in `layouts/admin.cfm` using `prc.hideBreadcrumbs` (defaults to shown)
> - Updates client script to check for `##breadcrumbs` before moving `div.top-right-button-group` into it, preventing errors when breadcrumbs are hidden
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 623366fc7d62618af3495c90f33b8a80bff18422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->